### PR TITLE
Use coincurve for faster signing

### DIFF
--- a/py_clob_client/signer.py
+++ b/py_clob_client/signer.py
@@ -1,4 +1,5 @@
-from eth_account import Account
+from coincurve import PrivateKey
+from eth_utils import keccak, to_checksum_address
 
 
 class Signer:
@@ -6,11 +7,15 @@ class Signer:
         assert private_key is not None and chain_id is not None
 
         self.private_key = private_key
-        self.account = Account.from_key(private_key)
+        key_hex = private_key[2:] if private_key.startswith("0x") else private_key
+        self._private_key = PrivateKey(bytes.fromhex(key_hex))
+        self._address = to_checksum_address(
+            keccak(self._private_key.public_key.format(compressed=False)[1:])[-20:]
+        )
         self.chain_id = chain_id
 
     def address(self):
-        return self.account.address
+        return self._address
 
     def get_chain_id(self):
         return self.chain_id
@@ -19,4 +24,15 @@ class Signer:
         """
         Signs a message hash
         """
-        return Account._sign_hash(message_hash, self.private_key).signature.hex()
+        if isinstance(message_hash, str):
+            msg_bytes = bytes.fromhex(
+                message_hash[2:] if message_hash.startswith("0x") else message_hash
+            )
+        else:
+            msg_bytes = message_hash
+
+        signature = self._private_key.sign_recoverable(msg_bytes, hasher=None)
+        r = signature[:32].hex()
+        s = signature[32:64].hex()
+        v = signature[64] + 27
+        return f"0x{r}{s}{v:02x}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black==24.4.2
-eth-account===0.13.0
+coincurve==18.0.0
 eth-utils===4.1.1
 poly_eip712_structs==0.0.1
 py_order_utils==0.3.2

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/Polymarket/py-clob-client",
     install_requires=[
-        "eth-account>=0.13.0",
+        "coincurve>=18.0.0",
         "eth-utils>=4.1.1",
         "poly_eip712_structs>=0.0.1",
         "py-order-utils>=0.3.2",


### PR DESCRIPTION
## Summary
- replace eth-account signer with coincurve-based signer for faster hashing/signing
- update dependencies to include coincurve

## Testing
- `pytest -q` *(fails: process hangs, but summary showed 56 passed before manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b363360d4c8332be3a42adb0e5f925